### PR TITLE
Use separate JSON file for configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+config.json

--- a/README.md
+++ b/README.md
@@ -17,32 +17,38 @@ For example, invoking on the hour every hour,
 Depending on your preferred log location, you may need to `touch` and `chmod/chown` the file beforehand. I considered `syslog` integration, but that's a pain and not as portable as it should be. 
 
 # Example configuration
-```
-LOG = '/var/log/trss.log'
-LOGLEVEL = logging.INFO
-HOST = 'localhost'
-PORT = 9091
-USER = None
-PASSWORD = None
-HTTP_HANDLER = None
-TIMEOUT = None
 
-FEEDS = [
-{
-'pattern' : '.*(some real name|another real name).*placebo resolution.*some subgroup.*Episode.*',
-'dl_dir' : '/a/',
-'subdirs' : True,
-'subdir_pattern' : '(.*) ::',
-'subdir_match_index' : 1,
-'url' : 'https://[redacted sekrit club :^)]'
-},
-{
-'pattern' : '.*(some real name|another real name).*Episode.*',
-'dl_dir' : '/tv/',
-'subdirs' : True,
-'subdir_pattern' : '(.*) ::',
-'subdir_match_index' : 1,
-'url' : 'https://[redacted sekrit club :^)]'
-}
-]
+Create a file `config.json` in the same directory as `trss.py`.
 ```
+{
+    "transmission": {
+        "http_handler": null,
+        "address": "localhost",
+        "user": null,
+        "timeout": null,
+        "password": null,
+        "port": 9091
+    },
+    "logging": {
+        "file": "/var/log/trss.log",
+        "level": "INFO"
+    },
+    "feeds": [
+        {
+            "pattern": ".*(some real name|another real name).*placebo resolution.*some subgroup.*Episode.*",
+            "dl_dir": "/a/",
+            "subdirs": true,
+            "subdir_pattern": "(.*) ::",
+            "subdir_match_index": 1,
+            "url": "https://[redacted sekrit club :^)]"
+        },
+        {
+            "pattern": ".*(some real name|another real name).*Episode.*",
+            "dl_dir": "/tv/",
+            "subdirs": true,
+            "subdir_pattern": "(.*) ::",
+            "subdir_match_index": 1,
+            "url": "https://[redacted sekrit club :^)]"
+        }
+    ]
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+git+git://github.com/kurtmckee/feedparser
+transmissionrpc==0.11

--- a/trss.py
+++ b/trss.py
@@ -8,11 +8,11 @@ import transmissionrpc
 
 LOG_LEVELS = {
     'NOTSET': logging.NOTSET,
-    'DEBUG': logging.debug,
-    'INFO': logging.info,
-    'WARNING': logging.warning,
-    'ERROR': logging.error,
-    'CRITICAL': logging.critical
+    'DEBUG': logging.DEBUG,
+    'INFO': logging.INFO,
+    'WARNING': logging.WARNING,
+    'ERROR': logging.ERROR,
+    'CRITICAL': logging.CRITICAL
 }
 
 CONFIG_FILE = file(os.path.join(os.path.dirname(__file__), 'config.json'))
@@ -58,5 +58,5 @@ except Exception:
 
 for feed in FEEDS:
     logger.info('Processing feed %s', feed['url'])
-    feed.update({'tc', client})
+    feed.update({'tc' : client})
     process_feed(**feed)


### PR DESCRIPTION
Separated configuration file into `config.json`. This should resolve #1.

I have not tested this (in any way) so it would be a good idea to do that before accepting.